### PR TITLE
Not loading slideshow fixed and unavailable picture deleted

### DIFF
--- a/src/app/components/ola-content-item/ola-content-item.component.html
+++ b/src/app/components/ola-content-item/ola-content-item.component.html
@@ -3,10 +3,12 @@
   [grayBox]="true"
 >
   <figure class="pl-0 lg:pl-8 pb-2 pr-0 pt-0 top-0 lg:float-right w-2/5 m-auto">
+    <!-- Image URL does not longer work
     <img
       src="https://strapi.esn-germany.de/uploads/Thumbnails_video_tutorials_OLA_squared_9fa38070e1.png"
       alt="online learning agreement"
     />
+    -->
   </figure>
   <p>
     The Erasmus+ programme foresees a gradual shift towards fully digital

--- a/src/app/pages/landing-page/landing-page.component.ts
+++ b/src/app/pages/landing-page/landing-page.component.ts
@@ -49,6 +49,7 @@ export class LandingPageComponent implements OnInit {
     this.mainService.getMainInformation().subscribe({
       next: (mainInfo?: MainItem) => {
         this.mainInfo = mainInfo;
+        this.setImages();
       },
       error: (error) => {
         console.error(error);


### PR DESCRIPTION
Landingpage: see [https://unifrankfurt.esn-germany.de/](https://unifrankfurt.esn-germany.de/) as an example the slideshow was not automatically loading

ola-content: unavailable URL of a picture deleted. The picture once was following (in case I am right )[https://esnturkey.org/sites/default/files/news/images/thumbnails_video_tutorials_ola_squared.png](https://esnturkey.org/sites/default/files/news/images/thumbnails_video_tutorials_ola_squared.png) 
I think this picture brings not much benefits therefore I just set it into comments.